### PR TITLE
SIMPLE-660: netlink golang library does not install on a fresh machine

### DIFF
--- a/addr_linux.go
+++ b/addr_linux.go
@@ -5,8 +5,8 @@ import (
 	"net"
 	"strings"
 
-	"github.com/vishvananda/netlink/nl"
-	"github.com/vishvananda/netns"
+	"github.com/rschmied/netlink/nl"
+	"github.com/rschmied/netns"
 	"golang.org/x/sys/unix"
 )
 

--- a/bridge_linux.go
+++ b/bridge_linux.go
@@ -3,7 +3,7 @@ package netlink
 import (
 	"fmt"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/rschmied/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/class_linux.go
+++ b/class_linux.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"syscall"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/rschmied/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/conntrack_linux.go
+++ b/conntrack_linux.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/rschmied/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/conntrack_test.go
+++ b/conntrack_test.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/vishvananda/netns"
+	"github.com/rschmied/netns"
 	"golang.org/x/sys/unix"
 )
 

--- a/filter_linux.go
+++ b/filter_linux.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/rschmied/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/fou_linux.go
+++ b/fou_linux.go
@@ -6,7 +6,7 @@ import (
 	"encoding/binary"
 	"errors"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/rschmied/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/genetlink_linux.go
+++ b/genetlink_linux.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"syscall"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/rschmied/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/gtp_linux.go
+++ b/gtp_linux.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/rschmied/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/handle_linux.go
+++ b/handle_linux.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/vishvananda/netlink/nl"
-	"github.com/vishvananda/netns"
+	"github.com/rschmied/netlink/nl"
+	"github.com/rschmied/netns"
 	"golang.org/x/sys/unix"
 )
 

--- a/handle_test.go
+++ b/handle_test.go
@@ -14,8 +14,8 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/vishvananda/netlink/nl"
-	"github.com/vishvananda/netns"
+	"github.com/rschmied/netlink/nl"
+	"github.com/rschmied/netns"
 	"golang.org/x/sys/unix"
 )
 

--- a/handle_unspecified.go
+++ b/handle_unspecified.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/vishvananda/netns"
+	"github.com/rschmied/netns"
 )
 
 type Handle struct{}

--- a/link_linux.go
+++ b/link_linux.go
@@ -10,8 +10,8 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/vishvananda/netlink/nl"
-	"github.com/vishvananda/netns"
+	"github.com/rschmied/netlink/nl"
+	"github.com/rschmied/netns"
 	"golang.org/x/sys/unix"
 )
 

--- a/link_test.go
+++ b/link_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vishvananda/netlink/nl"
-	"github.com/vishvananda/netns"
+	"github.com/rschmied/netlink/nl"
+	"github.com/rschmied/netns"
 	"golang.org/x/sys/unix"
 )
 

--- a/neigh_linux.go
+++ b/neigh_linux.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"unsafe"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/rschmied/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/netlink_linux.go
+++ b/netlink_linux.go
@@ -1,6 +1,6 @@
 package netlink
 
-import "github.com/vishvananda/netlink/nl"
+import "github.com/rschmied/netlink/nl"
 
 // Family type definitions
 const (

--- a/netlink_test.go
+++ b/netlink_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/vishvananda/netns"
+	"github.com/rschmied/netns"
 	"golang.org/x/sys/unix"
 )
 

--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -12,7 +12,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/vishvananda/netns"
+	"github.com/rschmied/netns"
 	"golang.org/x/sys/unix"
 )
 

--- a/order.go
+++ b/order.go
@@ -3,7 +3,7 @@ package netlink
 import (
 	"encoding/binary"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/rschmied/netlink/nl"
 )
 
 var (

--- a/protinfo_linux.go
+++ b/protinfo_linux.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"syscall"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/rschmied/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/qdisc_linux.go
+++ b/qdisc_linux.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/rschmied/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/route_linux.go
+++ b/route_linux.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/vishvananda/netlink/nl"
-	"github.com/vishvananda/netns"
+	"github.com/rschmied/netlink/nl"
+	"github.com/rschmied/netns"
 	"golang.org/x/sys/unix"
 )
 

--- a/route_test.go
+++ b/route_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vishvananda/netlink/nl"
-	"github.com/vishvananda/netns"
+	"github.com/rschmied/netlink/nl"
+	"github.com/rschmied/netns"
 	"golang.org/x/sys/unix"
 )
 

--- a/rule_linux.go
+++ b/rule_linux.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/rschmied/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/socket_linux.go
+++ b/socket_linux.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/rschmied/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/xfrm_monitor_linux.go
+++ b/xfrm_monitor_linux.go
@@ -3,8 +3,8 @@ package netlink
 import (
 	"fmt"
 
-	"github.com/vishvananda/netlink/nl"
-	"github.com/vishvananda/netns"
+	"github.com/rschmied/netlink/nl"
+	"github.com/rschmied/netns"
 	"golang.org/x/sys/unix"
 )
 

--- a/xfrm_monitor_test.go
+++ b/xfrm_monitor_test.go
@@ -5,7 +5,7 @@ package netlink
 import (
 	"testing"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/rschmied/netlink/nl"
 )
 
 func TestXfrmMonitorExpire(t *testing.T) {

--- a/xfrm_policy_linux.go
+++ b/xfrm_policy_linux.go
@@ -1,7 +1,7 @@
 package netlink
 
 import (
-	"github.com/vishvananda/netlink/nl"
+	"github.com/rschmied/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/xfrm_state_linux.go
+++ b/xfrm_state_linux.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"unsafe"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/rschmied/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 


### PR DESCRIPTION
Replace references to import from the github.com/vishvananda/netlink project
to be imports from the github.com/rschmied/netlink fork instead.  That should permit 
`go get githbub.com/rschmied/netlink` to succeed since it will no longer reference  
the original project, which has moved ahead in ways that break the current code 
on your fork.
